### PR TITLE
fix call to 'document.getElementById()' typo

### DIFF
--- a/16-Drink_Water/script.js
+++ b/16-Drink_Water/script.js
@@ -1,7 +1,7 @@
 const smallCups = document.querySelectorAll('.cup-small')
-const listers = document.getElementByID('liters')
-const percentage = document.getElementByID('percentage')
-const remained = document.getElementByID('remained')
+const liters = document.getElementById('liters')
+const percentage = document.getElementById('percentage')
+const remained = document.getElementById('remained')
 
 updateBigCup()
 
@@ -44,6 +44,6 @@ function updateBigCup() {
     remained.style.height = 0
   } else {
     remained.style.visibility = 'visible'
-    listers.innerText = `${2 - (250 * fullCups) / 1000}L`
+    liters.innerText = `${2 - (250 * fullCups) / 1000}L`
   }
 }


### PR DESCRIPTION
You were close on this one but the actual problem was that you were calling a function that doesn't exist. JavaScript functions are case sensitive, so `getElementById()` is not the same as `getElementByID()`. Also there was a typo in one of the variables: "listers" should be "liters".

Reference: https://www.w3schools.com/jsref/met_document_getelementbyid.asp